### PR TITLE
fixed md5 hashing for array of strings [keys]

### DIFF
--- a/lib/redis-memory-cache.js
+++ b/lib/redis-memory-cache.js
@@ -310,7 +310,7 @@ function RedisMemcacheClient(redisClient, redisSubClient, options, cb) {
         });
 
         if (fromRedis.length) {
-            var hash = crypto.createHash('md5').update(Buffer.from(keys)).digest("hex");
+            var hash = crypto.createHash('md5').update(keys.join(''), 'utf-8').digest("hex");
             if (Array.isArray(commandBeingDownloaded[hash])) {
                 //if the command is already being downloaded register a callback
                 commandBeingDownloaded[hash].push(this.mget.bind(this,keys, cb, json, jsonByRef));


### PR DESCRIPTION
`Buffer.from(array)` does not work as expected with an array of strings because when it is used with arrays it expects the array items to be bytes. So, it returns `0x0` for each array item if an array item is a string. This means arrays of strings that have the same number of elements generate the same data: `<Buffer 00 00 ... >`.

This situation affects the uniqueness of md5 values which are used in `mget()` function. When parallel functions are run concurrently by sending `keys` arrays with the same number of items, it creates problems.

Test code : 
```js
var crypto = require('crypto');

// this is expected usage for Buffer.from(array)
const arr1 = [ 0xd3, 0xf1 ];
const hash1 = crypto.createHash('md5').update(Buffer.from(arr1)).digest('hex');
console.log(arr1, hash1, Buffer.from(arr1));

const arr2 = [ 'foo', 'bar'];
const hash2 = crypto.createHash('md5').update(Buffer.from(arr2)).digest('hex');
console.log(arr2, hash2, Buffer.from(arr2));

const arr3 = [ 'bar', 'baz' ];
const hash3 = crypto.createHash('md5').update(Buffer.from(arr3)).digest('hex');

console.log(arr3, hash3, Buffer.from(arr3));
```

Output : 
```sh
[ 211, 241 ] '73ccdbcb6fb5ecdaf1eff788bd930a74' <Buffer d3 f1>
[ 'foo', 'bar' ] 'c4103f122d27677c9db144cae1394a66' <Buffer 00 00>
[ 'bar', 'baz' ] 'c4103f122d27677c9db144cae1394a66' <Buffer 00 00>
```

So, I replaced `Buffer.from` with `keys.join('')` to make keys array a string. 